### PR TITLE
Update package.json from utils package

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@react-slip-and-slide/utils",
   "version": "1.5.1",
-  "main": "./dist",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
@@ -35,7 +36,6 @@
   "description": "utils",
   "author": "João Ribeiro",
   "homepage": "https://github.com/joaorr3/react-slip-and-slide#readme",
-  "type": "module",
   "directories": {
     "dist": "./dist"
   },


### PR DESCRIPTION
Removed type module from package.json to fix: 

Module not found: Error: Can't resolve './components' in 'PROJECT_PATH/node_modules/@react-slip-and-slide/utils/dist' Did you mean 'index.js'?
BREAKING CHANGE: The request './components' failed to resolve only because it was resolved as fully specified (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"'). The extension in the request is mandatory for it to be fully specified. Add the extension to the request.